### PR TITLE
mz/kafka parallel runners

### DIFF
--- a/moya/service/kafka_consumer.py
+++ b/moya/service/kafka_consumer.py
@@ -75,8 +75,8 @@ class KafkaConsumer(KafkaBase):
         await self._check_started()
         return t.cast(dict[TopicPartition, list[ConsumerRecord]], await self.kafka.getmany(*partitions, timeout_ms=timeout_ms, max_records=max_records))
 
-    def __aiter__(self) -> ConsumerRecord:
-        return self.kafka.__aiter__()
+    def __aiter__(self) -> t.AsyncIterator[ConsumerRecord]:
+        return t.cast(t.AsyncIterator[ConsumerRecord], self.kafka.__aiter__())
 
     async def __anext__(self) -> ConsumerRecord:
         return await self.kafka.__anext__()

--- a/moya/service/kafka_consumer.py
+++ b/moya/service/kafka_consumer.py
@@ -71,7 +71,7 @@ class KafkaConsumer(KafkaBase):
         await self._check_started()
         return await self.kafka.getone()
 
-    async def getmany(self, *partitions: str, timeout_ms: int = 0, max_records: int | None = None) -> dict[TopicPartition, list[ConsumerRecord]]:
+    async def getmany(self, *partitions: str, timeout_ms: int = 1000, max_records: int | None = None) -> dict[TopicPartition, list[ConsumerRecord]]:
         await self._check_started()
         return t.cast(dict[TopicPartition, list[ConsumerRecord]], await self.kafka.getmany(*partitions, timeout_ms=timeout_ms, max_records=max_records))
 

--- a/moya/service/kafka_runner.py
+++ b/moya/service/kafka_runner.py
@@ -8,7 +8,8 @@ from opentelemetry import propagate, trace
 from opentelemetry.instrumentation.aiokafka.utils import _aiokafka_getter
 from opentelemetry.trace import Status, StatusCode
 
-from moya.service.kafka_consumer import KafkaConsumer, KafkaSettings
+from moya.service.kafka_consumer import ConsumerRecord, KafkaConsumer, KafkaSettings
+from moya.util.asyncpool import asyncpool_queue
 
 # OTEL other instrumentation is set up automatically by opentelemetry-instrument -a as we won't be forking
 tracer = trace.get_tracer(__name__)
@@ -36,15 +37,34 @@ class KafkaRunner(abc.ABC, Generic[T]):
     async def main() -> None:
         setup_logging()
         setup_sentry()
-        await KafkaUserDetailUpdater().run()
+        await KafkaUserDetailUpdater(worker_count=5).run()
 
     if __name__ == "__main__":
         asyncio.run(main())
+
+    If you are inserting records into a database, because of the network latency you likely want to run with
+    `worker_count=5` or so to ensure that the process_item() tasks run in parallel so that full CPU can be used.
     """
 
-    def __init__(self, consumer_group: str, topics: list[str]) -> None:
+    def __init__(
+        self,
+        consumer_group: str,
+        topics: list[str],
+        kafka_batch_size: int = 100,
+        worker_count: int = 1,
+    ) -> None:
+        """
+        :param consumer_group: The consumer group name to use
+        :param topics: The list of topics to consume from
+        :param kafka_batch_size: The number of records to fetch from Kafka at a time. The commit only happens after all
+            of these records have been processed so any bugs or process exit will cause this whole batch to be retried
+            by the next process meaning you may get duplicates but you should never loose records.
+        :param worker_count: The number of parallel instances of process_item() to run at a time
+        """
         self.consumer_group = consumer_group
         self.topics = topics
+        self.kafka_batch_size = kafka_batch_size
+        self.worker_count = worker_count
         self.consumer = KafkaConsumer(
             KafkaSettings(),
             consumer_group,
@@ -56,6 +76,7 @@ class KafkaRunner(abc.ABC, Generic[T]):
             enable_auto_commit=True,
             auto_offset_reset="latest",
         )
+        self.counter = 0
 
     @abc.abstractmethod
     def parse_record(self, topic: str, value: bytes) -> tuple[T, str] | None:
@@ -70,54 +91,68 @@ class KafkaRunner(abc.ABC, Generic[T]):
         "Process the item - insert into a database or similar"
         ...
 
+    async def _process_record(self, record: ConsumerRecord) -> None:
+        """
+        Process the given record from Kafka.
+        """
+        # Pull the propagated trace from the consumer message so it ties back to the original request
+        # TODO: Move this into a pythonlib util helper function.
+        context = propagate.extract(record.headers, getter=_aiokafka_getter)
+        with tracer.start_as_current_span("process-record", context=context) as span:
+            try:
+                result = self.parse_record(record.topic, record.value)
+                if result is None:
+                    return
+                item, logging_key = result
+            except Exception as e:
+                logger.exception(f"Received invalid JSON input for {record.value} (topic: {record.topic})", exc_info=e)
+                span.set_status(Status(StatusCode.ERROR))
+                span.set_attribute("error.message", str(e))
+                span.set_attribute("error.input", record.value)
+                # await run_in_background(self.consumer.kafka.commit())  # commit after logging the error
+                return
+
+            timestamp = datetime.fromtimestamp(record.timestamp / 1000)
+
+            try:
+                await self.process_item(item, timestamp)
+                self.counter += 1
+            except Exception as e:
+                span.set_status(Status(StatusCode.ERROR))
+                span.set_attribute("error.message", str(e))
+                span.set_attribute("error.input", record.value)
+
+                logger.exception(f"Error processing {logging_key} {record.value}", exc_info=e)
+                # Don't commit because we want to retry probably???
+            else:
+                # Doesn't matter if this fails for some reason, we can always re-process the record but we
+                # don't want to loose any records
+                # await run_in_background(self.consumer.kafka.commit())
+
+                logger.debug(f"Processed for {logging_key} lag {datetime.now() - timestamp}")
+                if self.counter % 1000 == 0:
+                    # TODO: Alert sentry if lag > 30 min or something? But only once... Look at avg
+                    # lag of the last few records.
+                    logger.info(f"Processed {self.counter} items, last lag for partition {record.partition} was {datetime.now() - timestamp}")
+
     async def run(self) -> None:
-        # TODO: Batch into a single txn for a number of updates in order to reduce database load?
-        async with self.consumer.run():
-            counter = 0
+        async with (
+            self.consumer.run(),
+            asyncpool_queue(self._process_record, worker_count=self.worker_count, maxsize=self.worker_count * 3) as queue,
+        ):
             while True:
                 try:
-                    record = await self.consumer.getone()
+                    records = await self.consumer.getmany(max_records=self.kafka_batch_size)
                 except Exception as e:
                     logger.exception("Unknown Kafka exception", exc_info=e)
                     await asyncio.sleep(0.1)
                     continue
 
-                # Pull the propagated trace from the consumer message so it ties back to the original request
-                # TODO: Move this into a pythonlib util helper function.
-                context = propagate.extract(record.headers, getter=_aiokafka_getter)
-                with tracer.start_as_current_span("process-record", context=context) as span:
-                    try:
-                        result = self.parse_record(record.topic, record.value)
-                        if result is None:
-                            continue
-                        item, logging_key = result
-                    except Exception as e:
-                        logger.exception(f"Received invalid JSON input for {record.value} (topic: {record.topic})", exc_info=e)
-                        span.set_status(Status(StatusCode.ERROR))
-                        span.set_attribute("error.message", str(e))
-                        span.set_attribute("error.input", record.value)
-                        # await run_in_background(self.consumer.kafka.commit())  # commit after logging the error
-                        continue
+                for topic, record_list in records.items():
+                    for record in record_list:
+                        await queue.put(record)
 
-                    timestamp = datetime.fromtimestamp(record.timestamp / 1000)
-
-                    try:
-                        await self.process_item(item, timestamp)
-                        counter += 1
-                    except Exception as e:
-                        span.set_status(Status(StatusCode.ERROR))
-                        span.set_attribute("error.message", str(e))
-                        span.set_attribute("error.input", record.value)
-
-                        logger.exception(f"Error processing {logging_key} {record.value}", exc_info=e)
-                        # Don't commit because we want to retry probably???
-                    else:
-                        # Doesn't matter if this fails for some reason, we can always re-process the record but we
-                        # don't want to loose any records
-                        # await run_in_background(self.consumer.kafka.commit())
-
-                        logger.debug(f"Processed for {logging_key} lag {datetime.now() - timestamp}")
-                        if counter % 1000 == 0:
-                            # TODO: Alert sentry if lag > 30 min or something? But only once... Look at avg
-                            # lag of the last few records.
-                            logger.info(f"Processed {counter} items, last lag for partition {record.partition} was {datetime.now() - timestamp}")
+                # Wait for all the tasks to complete so that we know all items have been fully processed. If one is
+                # particularly slow then this could cause some unnecessary waiting but it's a bit more robust than
+                # keeping unprocessed items in the queue from the previous kafka batch.
+                await queue.join()

--- a/moya/service/kafka_runner.py
+++ b/moya/service/kafka_runner.py
@@ -58,7 +58,7 @@ class KafkaRunner(abc.ABC, Generic[T]):
         :param topics: The list of topics to consume from
         :param kafka_batch_size: The number of records to fetch from Kafka at a time. The commit only happens after all
             of these records have been processed so any bugs or process exit will cause this whole batch to be retried
-            by the next process meaning you may get duplicates but you should never loose records.
+            by the next process meaning you may get duplicates but you should never lose records.
         :param worker_count: The number of parallel instances of process_item() to run at a time
         """
         self.consumer_group = consumer_group
@@ -126,7 +126,7 @@ class KafkaRunner(abc.ABC, Generic[T]):
                 # Don't commit because we want to retry probably???
             else:
                 # Doesn't matter if this fails for some reason, we can always re-process the record but we
-                # don't want to loose any records
+                # don't want to lose any records
                 # await run_in_background(self.consumer.kafka.commit())
 
                 logger.debug(f"Processed for {logging_key} lag {datetime.now() - timestamp}")

--- a/moya/util/asyncpool.py
+++ b/moya/util/asyncpool.py
@@ -3,6 +3,8 @@ import logging
 import typing as t
 from contextlib import asynccontextmanager
 
+from moya.util.background import run_in_background
+
 logger = logging.getLogger("asyncpool")
 
 T = t.TypeVar("T")
@@ -22,7 +24,7 @@ async def _run_worker(queue: asyncio.Queue[T], fn: t.Callable[[T], t.Awaitable[N
 
 
 @asynccontextmanager
-async def asyncpool(fn: t.Callable[[T], t.Awaitable[None]], worker_count: int = 5, maxsize: int = 0) -> t.AsyncIterator[t.Callable[[T], t.Awaitable[None]]]:
+async def asyncpool_queue(fn: t.Callable[[T], t.Awaitable[None]], worker_count: int = 5, maxsize: int = 0) -> t.AsyncIterator[asyncio.Queue[T]]:
     """
     Run a pool of workers to process items from a queue. The queue is returned
     from the context manager and can be used to enqueue items for processing.
@@ -40,19 +42,40 @@ async def asyncpool(fn: t.Callable[[T], t.Awaitable[None]], worker_count: int = 
     async def worker(item):
         ... do stuff ...
 
-    async def ...:
-        async with asyncpool(worker, worker_count=10) as enqueue:
+    async with asyncpool_queue(worker, worker_count=10) as queue:
+        for i in range(100):
             for i in range(100):
-                await enqueue(i)
+                await queue.put(i)
+            # ensure queue is flushed before going to next batch
+            await queue.join()
     """
 
     queue: asyncio.Queue[T] = asyncio.Queue(maxsize=maxsize)
-    workers = [asyncio.create_task(_run_worker(queue, fn)) for _ in range(worker_count)]
+    workers = [await run_in_background(_run_worker(queue, fn), name="asyncpool worker", force_run_in_background=True) for _ in range(worker_count)]
 
     try:
-        yield queue.put
+        yield queue
     finally:
         await queue.join()
         for worker in workers:
             worker.cancel()
         await asyncio.gather(*workers, return_exceptions=True)
+
+
+@asynccontextmanager
+async def asyncpool(fn: t.Callable[[T], t.Awaitable[None]], worker_count: int = 5, maxsize: int = 0) -> t.AsyncIterator[t.Callable[[T], t.Awaitable[None]]]:
+    """
+    As asyncpool_queue above but a function is returned that can be used to enqueue items for processing.
+
+    Usage:
+
+    async def worker(item):
+        ... do stuff ...
+
+    async with asyncpool(worker, worker_count=10) as enqueue:
+        for i in range(100):
+            await enqueue(i)
+    """
+
+    async with asyncpool_queue(fn, worker_count=worker_count, maxsize=maxsize) as queue:
+        yield queue.put

--- a/tests/util/test_asyncpool.py
+++ b/tests/util/test_asyncpool.py
@@ -1,0 +1,63 @@
+import asyncio
+import random
+import time
+
+import pytest
+
+from moya.util.asyncpool import asyncpool, asyncpool_queue
+
+
+async def test_basic_asyncpool() -> None:
+    items: list[int] = []
+
+    total_sleep = 0
+
+    async def worker(item):
+        nonlocal total_sleep
+        to_sleep = random.random() / 10
+        total_sleep += to_sleep
+        await asyncio.sleep(to_sleep)  # Yield to allow other tasks to run and to disorder the outputs
+        items.append(item * item)
+
+    start = time.time()
+    async with asyncpool_queue(worker, worker_count=10) as queue:
+        for i in range(100):
+            await queue.put(i)
+        await queue.join()  # Test we have full functionality
+    end = time.time()
+    assert end - start < total_sleep / 4, "Queue should have been processed in parallel workers"
+
+    assert items != [i * i for i in range(100)], "Queue should have been processed not in-order"
+    assert sorted(items) == [i * i for i in range(100)]
+
+    # Test with asyncpool now
+    total_sleep = 0
+    items = []
+    start = time.time()
+    async with asyncpool(worker, worker_count=10) as enqueue:
+        for i in range(100):
+            await enqueue(i)
+    end = time.time()
+    assert end - start < total_sleep / 4, "Queue should have been processed in parallel workers"
+
+    assert items != [i * i for i in range(100)], "Queue should have been processed not in-order"
+    assert sorted(items) == [i * i for i in range(100)]
+
+
+async def test_asyncpool_errors(caplog: pytest.LogCaptureFixture) -> None:
+    items: list[float] = []
+
+    async def worker(item):
+        items.append(10.0 / item)
+
+    # Pop some nulls into the queue to blow it up at various points
+    to_push = list(range(100)) + [0] * 5
+    random.shuffle(to_push)
+    async with asyncpool(worker, worker_count=10) as enqueue:
+        for i in to_push:
+            await enqueue(i)
+
+    assert sorted(items) == sorted([10.0 / i for i in range(1, 100)])
+    assert len(caplog.records) == 6
+    assert [r.exc_info[0] for r in caplog.records if r.exc_info] == [ZeroDivisionError] * 6
+    assert sum(("Error processing item 0" in r.getMessage() for r in caplog.records)) == 6


### PR DESCRIPTION
- **Add tests and expose the asyncpool queue where necessary**
- **Extend kafka runner to handle multiple records in parallel to fully exhaust CPU when being used**
